### PR TITLE
Fixed ExecutionStatus to comply with resources provided by GSMA 3.2

### DIFF
--- a/src/io/njiwa/common/ws/types/BaseResponseType.java
+++ b/src/io/njiwa/common/ws/types/BaseResponseType.java
@@ -80,13 +80,13 @@ public class BaseResponseType implements RpsElement {
 
         @XmlEnum(String.class)
         public enum Status {
-            @XmlEnumValue("Executed-Success")
+            @XmlEnumValue("EXECUTED_SUCCESS")
             ExecutedSuccess,
-            @XmlEnumValue("Executed-WithWarning")
+            @XmlEnumValue("EXECUTED_WITHWARNING")
             ExecutedWithWarning,
-            @XmlEnumValue("Failed")
+            @XmlEnumValue("FAILED")
             Failed,
-            @XmlEnumValue("Expired")
+            @XmlEnumValue("EXPIRED")
             Expired;
 
             public static Transport.MessageStatus toTransMsgStatus(ExecutionStatus.Status status, Transport


### PR DESCRIPTION
Fixed execution status in order to comply with resources provided by GSMA

Refer to : https://www.gsma.com/newsroom/resources/sgp-02-v3-2-remote-provisioning-architecture-for-embedded-uicc-technical-specification/

SGP.02 v3.2 Files (Zip)/xsd/euicc.common.types.xsd -> `StatusType`

```
<xs:simpleType name="StatusType">
        <xs:annotation>
            <xs:documentation>It indicates whether the processing has been completed correctly or not.</xs:documentation>
        </xs:annotation>
        <xs:restriction base="xs:string">
            <xs:enumeration value="EXECUTED_SUCCESS"/>
            <xs:enumeration value="EXECUTED_WITHWARNING"/>
            <xs:enumeration value="FAILED"/>
            <xs:enumeration value="EXPIRED"/>
        </xs:restriction>
    </xs:simpleType>
```